### PR TITLE
Remove the current top card with a custom animation.

### DIFF
--- a/cardstack/src/main/java/com/daprlabs/cardstack/SwipeDeck.java
+++ b/cardstack/src/main/java/com/daprlabs/cardstack/SwipeDeck.java
@@ -1,20 +1,18 @@
 package com.daprlabs.cardstack;
 
+import android.animation.Animator;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.database.DataSetObserver;
-import android.os.AsyncTask;
 import android.os.Build;
-import android.os.Parcelable;
 import android.support.v4.view.ViewCompat;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.animation.Animation;
 import android.widget.Adapter;
 import android.widget.FrameLayout;
-
 import java.util.ArrayList;
 
 /**
@@ -52,6 +50,7 @@ public class SwipeDeck extends FrameLayout {
     private int leftImageResource;
     private int rightImageResource;
     private boolean cardInteraction;
+    private Animator.AnimatorListener removeTopCardOnAnimationEndAnimatorListener;
 
     public SwipeDeck(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -91,6 +90,24 @@ public class SwipeDeck extends FrameLayout {
         if (RENDER_BELOW) {
             ViewCompat.setTranslationZ(this, Float.MIN_VALUE);
         }
+
+        removeTopCardOnAnimationEndAnimatorListener = new Animator.AnimatorListener() {
+            @Override public void onAnimationStart(Animator animation) {
+
+            }
+
+            @Override public void onAnimationEnd(Animator animation) {
+                removeTopCard();
+            }
+
+            @Override public void onAnimationCancel(Animator animation) {
+
+            }
+
+            @Override public void onAnimationRepeat(Animator animation) {
+
+            }
+        };
     }
 
     /**
@@ -187,15 +204,12 @@ public class SwipeDeck extends FrameLayout {
         if (child != null) {
             child.setOnTouchListener(null);
             swipeListener = null;
-            //this will also check to see if cards are depleted
-            removeViewWaitForAnimation(child);
+            removeView(child);
+            //if there are no more children left after top card removal let the callback know
+            if (getChildCount() <= 0 && eventCallback != null) {
+                eventCallback.cardsDepleted();
+            }
         }
-    }
-
-    private void removeViewWaitForAnimation(View child) {
-        new RemoveViewOnAnimCompleted().execute(child);
-
-
     }
 
     @Override
@@ -407,12 +421,26 @@ public class SwipeDeck extends FrameLayout {
 
         int childCount = getChildCount();
         if (childCount > 0 && getChildCount() < (NUMBER_OF_CARDS + 1)) {
-            swipeListener.animateOffScreenLeft(duration);
+            swipeListener.animateOffScreenLeft(duration).setListener(new Animator.AnimatorListener() {
+                @Override public void onAnimationStart(Animator animation) {
 
-            int positionInAdapter = nextAdapterCard - getChildCount();
-            removeTopCard();
-            if (eventCallback != null) eventCallback.cardSwipedLeft(positionInAdapter);
-            addNextCard();
+                }
+
+                @Override public void onAnimationEnd(Animator animation) {
+                    int positionInAdapter = nextAdapterCard - getChildCount();
+                    removeTopCard();
+                    if (eventCallback != null) eventCallback.cardSwipedLeft(positionInAdapter);
+                    addNextCard();
+                }
+
+                @Override public void onAnimationCancel(Animator animation) {
+
+                }
+
+                @Override public void onAnimationRepeat(Animator animation) {
+
+                }
+            });
         }
 
     }
@@ -420,12 +448,58 @@ public class SwipeDeck extends FrameLayout {
     public void swipeTopCardRight(int duration) {
         int childCount = getChildCount();
         if (childCount > 0 && getChildCount() < (NUMBER_OF_CARDS + 1)) {
-            swipeListener.animateOffScreenRight(duration);
+            swipeListener.animateOffScreenRight(duration).setListener(new Animator.AnimatorListener() {
+                @Override public void onAnimationStart(Animator animation) {
 
-            int positionInAdapter = nextAdapterCard - getChildCount();
-            removeTopCard();
-            if (eventCallback != null) eventCallback.cardSwipedRight(positionInAdapter);
-            addNextCard();
+                }
+
+                @Override public void onAnimationEnd(Animator animation) {
+                    int positionInAdapter = nextAdapterCard - getChildCount();
+                    removeTopCard();
+                    if (eventCallback != null) eventCallback.cardSwipedRight(positionInAdapter);
+                    addNextCard();
+                }
+
+                @Override public void onAnimationCancel(Animator animation) {
+
+                }
+
+                @Override public void onAnimationRepeat(Animator animation) {
+
+                }
+            });
+        }
+    }
+
+    public void removeTopCardWithOffScreenTopAnimation() {
+        int childCount = getChildCount();
+        if (childCount > 0 && getChildCount() < (NUMBER_OF_CARDS + 1)) {
+            if (swipeListener != null) {
+                swipeListener.animateOffScreenTop(400).setListener(
+                    removeTopCardOnAnimationEndAnimatorListener);
+            }
+        }
+    }
+
+    public void removeTopCardWithCustomAnimation(Animation animation) {
+        int childCount = getChildCount();
+        if (childCount > 0 && getChildCount() < (NUMBER_OF_CARDS + 1)) {
+            if (swipeListener != null) {
+                animation.setAnimationListener(new Animation.AnimationListener() {
+                                                   @Override public void onAnimationStart(Animation animation) {
+
+                                                   }
+
+                                                   @Override public void onAnimationEnd(Animation animation) {
+                                                        removeTopCard();
+                                                   }
+
+                                                   @Override public void onAnimationRepeat(Animation animation) {
+
+                                                   }
+                                               });
+                    swipeListener.animate(animation);
+            }
         }
     }
 
@@ -440,6 +514,8 @@ public class SwipeDeck extends FrameLayout {
     public void setRightImage(int imageResource) {
         rightImageResource = imageResource;
     }
+
+
 
     public interface SwipeEventCallback {
         //returning the object position in the adapter
@@ -459,26 +535,6 @@ public class SwipeDeck extends FrameLayout {
         void yPos(Float y);
     }
 
-    private int AnimationTime = 160;
-    private class RemoveViewOnAnimCompleted extends AsyncTask<View, Void, View> {
-
-        @Override
-        protected View doInBackground(View... params) {
-            android.os.SystemClock.sleep(AnimationTime);
-            return params[0];
-        }
-
-        @Override
-        protected void onPostExecute(View view) {
-            super.onPostExecute(view);
-            removeView(view);
-
-            //if there are no more children left after top card removal let the callback know
-            if (getChildCount() <= 0 && eventCallback != null) {
-                eventCallback.cardsDepleted();
-            }
-        }
-    }
 }
 
 

--- a/cardstack/src/main/java/com/daprlabs/cardstack/SwipeListener.java
+++ b/cardstack/src/main/java/com/daprlabs/cardstack/SwipeListener.java
@@ -1,11 +1,11 @@
 package com.daprlabs.cardstack;
 
 import android.animation.Animator;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewPropertyAnimator;
+import android.view.animation.Animation;
 import android.view.animation.OvershootInterpolator;
 
 /**
@@ -251,6 +251,16 @@ public class SwipeListener implements View.OnTouchListener {
                 .x(parentWidth * 2)
                 .y(0)
                 .rotation(30);
+    }
+
+    public ViewPropertyAnimator animateOffScreenTop(int duration) {
+        return card.animate()
+            .setDuration(duration)
+            .translationYBy(-parent.getHeight());
+    }
+
+    public void animate(Animation animation) {
+        card.startAnimation(animation);
     }
 
     public void setRightView(View image) {


### PR DESCRIPTION
This adds two public methods to your library that extends the API. 

`removeTopCardWithOffScreenTopAnimation()`
and
`removeTopCardWithCustomAnimation(Animation animation) `

I also removed `RemoveViewOnAnimCompleted extends AsyncTask` since is not really useful if we  have the `AnimatorListener`class that do this stuff by us.
